### PR TITLE
Make wrappers work on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var createCommonjsPreprocessor = function(args, config, logger, helper) {
     // we assume that we're in node_modules/karma-commonjs-preprocessor
     // therefore we just strip everything that is over the ../../ level
     var karmaRoot = path.normalize(__dirname + '/../..');
-    return origPath.replace(karmaRoot + '/', '');
+    return origPath.substring(karmaRoot.length + 1);
   };
 
   var indentStr = function(str) {

--- a/index.js
+++ b/index.js
@@ -55,8 +55,8 @@ var createCommonjsPreprocessor = function(args, config, logger, helper) {
 
 
     try {
-      result = wrapDefine(file.path, content)
-      done(result)
+      result = wrapDefine(file.path, content);
+      done(result);
     } catch (e) {
       log.error('%s\n  at %s', e.message, file.originalPath);
       return;


### PR DESCRIPTION
When using string replace with a hard-coded forward slash makes our build server, that unfortunately runs windows, very unhappy.
All files are registered using the module name "c:/users/buildbot/repo/modules/sauce" instead of "modules/sauce".

This commit makes rebasePath compatible with windows (__dirname begins with a drive-letter and contains backslashes in the path). 
